### PR TITLE
Fix a bug with the group parameter

### DIFF
--- a/classes/captcha.php
+++ b/classes/captcha.php
@@ -158,7 +158,7 @@ abstract class Captcha
 	public function update_response_session()
 	{
 		// Store the correct Captcha response in a session
-		Session::instance()->set('captcha_response', sha1(strtoupper($this->response)));
+		Session::instance()->set('captcha_response', sha1(utf8::strtoupper($this->response)));
 	}
 
 	/**
@@ -178,7 +178,7 @@ abstract class Captcha
 			return TRUE;
 
 		// Challenge result
-		$result = (bool) (sha1(strtoupper($response)) === Session::instance()->get('captcha_response'));
+		$result = (bool) (sha1(utf8::strtoupper($response)) === Session::instance()->get('captcha_response'));
 
 		// Increment response counter
 		if ($counted !== TRUE)

--- a/classes/captcha/basic.php
+++ b/classes/captcha/basic.php
@@ -51,11 +51,11 @@ class Captcha_Basic extends Captcha
 		}
 
 		// Calculate character font-size and spacing
-		$default_size = min(Captcha::$config['width'], Captcha::$config['height'] * 2) / (strlen($this->response) + 1);
-		$spacing = (int) (Captcha::$config['width'] * 0.9 / strlen($this->response));
+		$default_size = min(Captcha::$config['width'], Captcha::$config['height'] * 2) / (utf8::strlen($this->response) + 1);
+		$spacing = (int) (Captcha::$config['width'] * 0.9 / utf8::strlen($this->response));
 
 		// Draw each Captcha character with varying attributes
-		for ($i = 0, $strlen = strlen($this->response); $i < $strlen; $i++)
+		for ($i = 0, $strlen = utf8::strlen($this->response); $i < $strlen; $i++)
 		{
 			// Use different fonts if available
 			$font = Captcha::$config['fontpath'].Captcha::$config['fonts'][array_rand(Captcha::$config['fonts'])];
@@ -66,14 +66,14 @@ class Captcha_Basic extends Captcha
 
 			// Scale the character size on image height
 			$size = $default_size / 10 * mt_rand(8, 12);
-			$box = imageftbbox($size, $angle, $font, $this->response[$i]);
+			$box = imageftbbox($size, $angle, $font, utf8::substr($this->response, $i, 1));
 
 			// Calculate character starting coordinates
 			$x = $spacing / 4 + $i * $spacing;
 			$y = Captcha::$config['height'] / 2 + ($box[2] - $box[5]) / 4;
 
 			// Write text character to image
-			imagefttext($this->image, $size, $angle, $x, $y, $color, $font, $this->response[$i]);
+			imagefttext($this->image, $size, $angle, $x, $y, $color, $font, utf8::substr($this->response, $i, 1));
 		}
 
 		// Output

--- a/classes/captcha/black.php
+++ b/classes/captcha/black.php
@@ -49,9 +49,9 @@ class Captcha_Black extends Captcha
 		$font = Captcha::$config['fontpath'].Captcha::$config['fonts'][array_rand(Captcha::$config['fonts'])];
 
 		// Draw the character's white shadows
-		$size = (int) min(Captcha::$config['height'] / 2, Captcha::$config['width'] * 0.8 / strlen($this->response));
-		$angle = mt_rand(-15 + strlen($this->response), 15 - strlen($this->response));
-		$x = mt_rand(1, Captcha::$config['width'] * 0.9 - $size * strlen($this->response));
+		$size = (int) min(Captcha::$config['height'] / 2, Captcha::$config['width'] * 0.8 / utf8::strlen($this->response));
+		$angle = mt_rand(-15 + utf8::strlen($this->response), 15 - utf8::strlen($this->response));
+		$x = mt_rand(1, Captcha::$config['width'] * 0.9 - $size * utf8::strlen($this->response));
 		$y = ((Captcha::$config['height'] - $size) / 2) + $size;
 		$color = imagecolorallocate($this->image, 255, 255, 255);
 		imagefttext($this->image, $size, $angle, $x + 1, $y + 1, $color, $font, $this->response);

--- a/classes/captcha/word.php
+++ b/classes/captcha/word.php
@@ -26,12 +26,12 @@ class Captcha_Word extends Captcha_Basic
 		foreach ($words as $word)
 		{
 			// ...until we find one of the desired length
-			if (abs(Captcha::$config['complexity'] - strlen($word)) < 2)
-				return strtoupper($word);
+			if (abs(Captcha::$config['complexity'] - utf8::strlen($word)) < 2)
+				return utf8::strtoupper($word);
 		}
 		
 		// Return any random word as final fallback
-		return strtoupper($words[array_rand($words)]);
+		return utf8::strtoupper($words[array_rand($words)]);
 	}
 
 } // End Captcha Word Driver Class

--- a/classes/controller/captcha.php
+++ b/classes/controller/captcha.php
@@ -25,10 +25,11 @@ class Controller_Captcha extends Controller {
 	 *
 	 * @param string $group Config group name
 	 */
-	public function action_index($group = 'default')
+	public function action_index()
 	{
 		// Output the Captcha challenge resource (no html)
 		// Pull the config group name from the URL
+		$group = $this->request->param('group', 'default');
 		Captcha::instance($group)->render(FALSE);
 	}
 	

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -29,7 +29,7 @@ return array(
 		'promote'    	=> FALSE,
 	),
 	// Words of varying length for Captcha_Word to pick from
-	// Note: use only alphanumeric characters
+	// Note: all Unicode characters should work, but not everyone can type them, so be careful with that (no japanese/chinese captcha please ;))
 	'words' => array
 	(
 		'cd', 'tv', 'it', 'to', 'be', 'or',


### PR DESCRIPTION
In some rare cases, this fixes a bug that prevent Captcha to load the correct route to it.
The effect is the same than before but uses an explicit reference to the argument instead of an implicit.
